### PR TITLE
docs: remove completed items from TODO

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,11 +1,5 @@
 # leanyolo TODO
 
-Status (2025‑09‑01)
-- Dataset prep: `tools/prepare_acquirium.py` added (Windows‑friendly; no symlinks). Done.
-- Transfer script: `tools/transfer_learn_aquarium.py` added with AMP default, warmup+cosine LR, light aug, gradual unfreeze, detailed logging. Done.
-- Baseline trainer moved to `tools/train.py`. Done.
-- Eval helper: `evaluate_coco` renamed to `evaluate` (COCO‑format mAP). Done.
-
 Recent results
 - Aquarium (COCO‑format), yolov10m @ 640, 50 epochs, batch 32, AMP: best mAP50‑95 ≈ 0.389 at epoch 35.
 


### PR DESCRIPTION
## Summary
- drop outdated status entries from todo list to keep focus on remaining tasks

## Testing
- `./.venv/bin/python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5c40c0688330a5407f89bf723cb5