### PR TITLE
fix: use timezone-aware datetime for logging

### DIFF
--- a/leanyolo/tests/test_val_log_unit.py
+++ b/leanyolo/tests/test_val_log_unit.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import warnings
+
 from leanyolo.utils import val_log as V
 
 
@@ -47,7 +49,9 @@ def test_ensure_csv_migrates_existing_header(tmp_path):
 def test_collect_env_and_now_iso():
     env = V.collect_env_info(device="cpu")
     assert set(["commit", "host", "device", "device_name"]).issubset(env)
-    # timestamp format quick check
-    ts = V.now_iso()
+    # timestamp format quick check and ensure no deprecation warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("error", DeprecationWarning)
+        ts = V.now_iso()
     assert ts.endswith("Z") and "T" in ts
 

--- a/leanyolo/utils/val_log.py
+++ b/leanyolo/utils/val_log.py
@@ -4,7 +4,7 @@ import csv
 import platform
 import socket
 import subprocess
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, Optional
 
@@ -121,4 +121,12 @@ def append_row(path: Path, values: Mapping[str, object], *, columns: Iterable[st
 
 
 def now_iso() -> str:
-    return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    """Return current UTC time in ISO 8601 format without microseconds.
+
+    Uses timezone-aware :func:`datetime.now` with :data:`datetime.UTC` to avoid
+    the deprecated :func:`datetime.utcnow`. The trailing ``"+00:00"`` is
+    replaced with ``"Z"`` for brevity.
+    """
+    return (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )


### PR DESCRIPTION
## Summary
- avoid deprecated `datetime.utcnow` in `now_iso`
- add regression test ensuring no `DeprecationWarning`

## Testing
- `./.venv/bin/python -m pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c79ab7e7ec83308bf499c8c977f714